### PR TITLE
changed payment api endpoint

### DIFF
--- a/src/Message/FetchPaymentMethodsRequest.php
+++ b/src/Message/FetchPaymentMethodsRequest.php
@@ -19,6 +19,14 @@ class FetchPaymentMethodsRequest extends AbstractRequest {
     }
 
     /**
+     * Override the fetch payment API because the proxy has no support for this endpoint
+     * @return string
+     */
+    public function getEndpoint() {
+        return 'https://api.cmpayments.com';
+    }
+    
+    /**
      * Get the raw data array for this message. The format of this varies from gateway to
      * gateway, but will usually be either an associative array, or a SimpleXMLElement.
      *


### PR DESCRIPTION
Let the payment methods run trough the default api endpoint,
The proxy has no support for this endpoint.